### PR TITLE
CA Certificate capabilities and Pre-Login Authentication Check

### DIFF
--- a/CASAuthSettings.php.template
+++ b/CASAuthSettings.php.template
@@ -37,6 +37,16 @@ $CASAuth["Port"]=443;
 # Default: $CASAuth["Url"]="/cas/";
 $CASAuth["Url"]="/cas/"; 
 
+# CA Certificate Settings
+#
+# Set UseCert to true if you need to use a CA certificate to authenticate
+# then set Cert to the certificate location.
+#
+# Default: $CASAuth["UseCert"]=false;
+# Default: $CASAuth["Cert"]="/crt/cert.crt";
+$CASAuth["UseCert"]=false;
+$CASAuth["Cert"]="/crt/cert.crt";
+
 # CAS Version.  Available versions are "1.0" and "2.0".
 #
 # Default: $CASAuth["Version"]="2.0";

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-CASAuth(entication) Extension for Mediawiki
-===========================================
+CASAuth Extension for Mediawiki
+===============================
+This is compatible with version MediaWiki version 1.33
 
-A CAS Authentication extension for Mediawiki 1.27, 1.23 (and possibly
-earlier).
+This differs from the original by offering a new CA Certificate setting that is implemented in the casSetup function.
+
+It also adds a check in casLogin() to see whether a user is already authenticated through another web application before forcing the authentication. This ensures that the phpCAS:getUser() method is able to get the username in the event the user is already authenticated through another session, and prevents the user from needing to log out of their institution's applications before logging into the MediaWiki.
+
+This is forked from the CWRUChielLab/CASAuth repo, both this version and the original seem to be compatible with newer versions of MediaWiki.
+
+Below is the original README content from CWRUChielLab/CASAuth :
+
 
 Introduction
 ------------


### PR DESCRIPTION
This PR proposes a new CA Certificate setting that is implemented in the casSetup function.

It also adds a check in casLogin() to see whether a user is already authenticated through another web application before forcing the authentication. This ensures that the phpCAS:getUser() method is able to get the username in the event the user is already authenticated through another session, and prevents the user from needing to log out of their institution's applications before logging into the MediaWiki.